### PR TITLE
Add case sensitive option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,39 @@ Then configure the rule under the rules section.
     }
 }
 ```
+
+## Rule Options
+
+```json
+{
+    "sort-destructure-keys/sort-destructure-keys": [2, {"caseSensitive": false}]
+}
+```
+
+### `caseSensitive`
+
+When `true` the rule will enforce properties to be in case-sensitive order. Default is `false`.
+
+Example of **incorrect** code for the `{"caseSensitive": false}` option:
+
+```js
+let {B, a, c} = obj;
+```
+
+Example of **correct** code for the `{"caseSensitive": false}` option:
+
+```js
+let {a, B, c} = obj;
+```
+
+Example of **incorrect** code for the `{"caseSensitive": true}` option:
+
+```js
+let {a, B, c} = obj;
+```
+
+Example of **correct** code for the `{"caseSensitive": true}` option:
+
+```js
+let {B, a, c} = obj;
+```

--- a/lib/rules/sort-destructure-keys.js
+++ b/lib/rules/sort-destructure-keys.js
@@ -44,7 +44,17 @@ module.exports = {
         messages: {
             sort: `Expected object keys to be in sorted order. Expected {{first}} to be before {{second}}.`
         },
-        schema: []
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                  caseSensitive: {
+                    type: 'boolean',
+                  }
+                },
+                additionalProperties: false
+            }
+        ]
     },
 
     create(context) {
@@ -59,14 +69,18 @@ module.exports = {
                     return;
                 }
 
+                const options = context.options[0] || {};
+                const caseSensitive = options.caseSensitive || false;
                 let prevNode = null;
 
                 for (const nextNode of node.properties) {
                     if (prevNode && !isRestProperty(nextNode)) {
                         const prevName = getNodeName(prevNode.key);
                         const nextName = getNodeName(nextNode.key);
+                        const first = caseSensitive ? prevName : prevName.toLowerCase();
+                        const second = caseSensitive ? nextName : nextName.toLowerCase();
 
-                        if (naturalCompare(prevName.toLowerCase(), nextName.toLowerCase()) > 0) {
+                        if (naturalCompare(first, second) > 0) {
                             context.report({
                                 node: nextNode,
                                 messageId: 'sort',

--- a/tests/lib/rules/sort-destructure-keys.js
+++ b/tests/lib/rules/sort-destructure-keys.js
@@ -31,6 +31,18 @@ ruleTester.run('sort-destructure-keys', rule, {
         'const {...other} = someObj;',
         'const func = ({a, b}) => a + b;',
         'const {a: {b, c}, d: {e, f: {g}}} = someObj;',
+        {
+            code: 'const {a, b} = someObj;',
+            options: [{ caseSensitive: true }]
+        },
+        {
+            code: 'const {B, a} = someObj;',
+            options: [{ caseSensitive: true }]
+        },
+        {
+            code: 'const {aCc, abb} = someObj;',
+            options: [{ caseSensitive: true }]
+        }
     ],
     invalid: [
         {
@@ -64,6 +76,21 @@ ruleTester.run('sort-destructure-keys', rule, {
         {
             code: 'const {a, c: {e, d}, b = c} = someObj;',
             errors: [msg('e', 'd')]
+        },
+        {
+            code: 'const {b, a} = someObj;',
+            errors: just('b', 'a'),
+            options: [{ caseSensitive: true }]
+        },
+        {
+            code: 'const {a, B} = someObj;',
+            errors: just('a', 'B'),
+            options: [{ caseSensitive: true }]
+        },
+        {
+            code: 'const {abc, aBd} = someObj;',
+            errors: just('abc', 'aBd'),
+            options: [{ caseSensitive: true }]
         },
     ]
 });


### PR DESCRIPTION
This adds the `caseSensitive` option. When this option is `true` the rule will enforce properties to be in case-sensitive order. Default is `false` so that this isn't a breaking change.
