### PR TITLE
Fix null reference error

### DIFF
--- a/lib/rules/sort-destructure-keys.js
+++ b/lib/rules/sort-destructure-keys.js
@@ -53,8 +53,8 @@ function createFix({context, fixer, node, caseSensitive}) {
     const sorted = node.properties
         .concat()
         .sort((a, b) => naturalCompare(
-            sortName(a.key.name),
-            sortName(b.key.name)
+            sortName(a.key && a.key.name),
+            sortName(b.key && b.key.name)
         ))
 
     const newText = sorted


### PR DESCRIPTION
Was coming across an ESLint error with some of my code. I don't know ESLint or this plugin well enough to give you an explanation of why this occurs but it seems that the ESLint AST does not always contain a key which was causing a fatal error. This seems to resolve that without breaking anything. Given that this is a comparison it should be semantically the same.