### PR TITLE
Make sure rest properties aren't sorted incorrectly

### DIFF
--- a/lib/rules/sort-destructure-keys.js
+++ b/lib/rules/sort-destructure-keys.js
@@ -52,10 +52,16 @@ function createFix({context, fixer, node, caseSensitive}) {
 
     const sorted = node.properties
         .concat()
-        .sort((a, b) => naturalCompare(
-            sortName(a.key.name),
-            sortName(b.key.name)
-        ))
+        .sort((a, b) => {
+            // Make sure rest properties always come later.
+            if (isRestProperty(a)) {
+                return 1;
+            } else if (isRestProperty(b)) {
+                return -1;
+            }
+
+            return naturalCompare(sortName(a.key.name), sortName(b.key.name));
+        });
 
     const newText = sorted
         .map((child, i) => {

--- a/tests/lib/rules/sort-destructure-keys.js
+++ b/tests/lib/rules/sort-destructure-keys.js
@@ -33,6 +33,7 @@ ruleTester.run('sort-destructure-keys', rule, {
         'const {a: foo, b} = someObj;',
         'const {b, a = b} = someObj;',
         'const {a = {}, b = {}} = someObj;',
+        'const {a, ...other} = someObj;',
         'const {a, b, ...other} = someObj;',
         'const {...other} = someObj;',
         'const func = ({a, b}) => a + b;',
@@ -164,5 +165,27 @@ ruleTester.run('sort-destructure-keys', rule, {
             output: 'const {aBd, abc} = someObj;',
             options: [{ caseSensitive: true }]
         },
+        {
+            code: 'const {b, a, ...rest} = someObj;',
+            errors: just('b', 'a'),
+            output: 'const {a, b, ...rest} = someObj;'
+        },
+        {
+            code: `
+                function foo({
+                    b = false,
+                    a,
+                    ...rest
+                }) {}
+            `,
+            errors: just('b', 'a'),
+            output: `
+                function foo({
+                    a,
+                    b = false,
+                    ...rest
+                }) {}
+            `
+        }
     ]
 });


### PR DESCRIPTION
Rest properties were being sorted incorrectly by the fixer, or sometimes causing it to throw errors. This should hopefully prevent that in the future.

Fixes #11 and fixes #12.