### PR TITLE
Fix eslint 7 incompatibility warning (fixes #52)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "format": "prettier --write \"{lib,tests}/**/*.js\""
   },
   "peerDependencies": {
-    "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
+    "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "dependencies": {
     "natural-compare-lite": "^1.4.0"


### PR DESCRIPTION
Simple `package.json` update to mark eslint 7 a valid `peerDependency`. 

Fixes #52