### PR TITLE
New "sortWithDefaultValues" option to sort even with default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Then configure the rule under the rules section.
 
 ```json
 {
-    "sort-destructure-keys/sort-destructure-keys": [2, {"caseSensitive": false}]
+    "sort-destructure-keys/sort-destructure-keys": [2, {"caseSensitive": false, "sortWithDefaultValues": false}]
 }
 ```
 
@@ -75,6 +75,27 @@ Example of **correct** code for the `{"caseSensitive": true}` option:
 
 ```js
 let {B, a, c} = obj;
+```
+
+
+### `sortWithDefaultValues`
+
+When `false` the rule will sort keys with default values. Default is `true`.
+
+Example of **incorrect** code for the `{"sortWithDefaultValues": false}` option:
+
+```js
+const foo = 'bar'
+
+let {b, a = foo} = obj;
+```
+
+Example of **correct** code for the `{"sortWithDefaultValues": false}` option:
+
+```js
+const foo = 'bar'
+
+let {a = foo, b} = obj;
 ```
 
 ## Changelog

--- a/lib/rules/sort-destructure-keys.js
+++ b/lib/rules/sort-destructure-keys.js
@@ -158,6 +158,9 @@ module.exports = {
           caseSensitive: {
             type: "boolean",
           },
+          sortWithDefaultValues: {
+            type: "boolean",
+          }
         },
         additionalProperties: false,
       },
@@ -166,7 +169,7 @@ module.exports = {
 
   create(context) {
     const options = context.options[0] || {};
-    const { caseSensitive = true } = options;
+    const { caseSensitive = true, sortWithDefaultValues = true } = options;
     const sorter = createSorter(caseSensitive);
 
     return {
@@ -176,7 +179,7 @@ module.exports = {
          * with literal defaults, we just skip it. If some values use
          * previous values as defaults, then we cannot simply sort them.
          */
-        if (!node.properties.every(shouldCheck)) {
+        if (sortWithDefaultValues && !node.properties.every(shouldCheck)) {
           return;
         }
 


### PR DESCRIPTION
There is a rule, mentioned in [this issue](https://github.com/mthadley/eslint-plugin-sort-destructure-keys/issues/18), stating that we cannot simply sort keys with default values. 
This PR brings the ability to skip this check by using sortWithDefaultValues.