### PR TITLE
Update CI: Use `actions/setup-node` and use `matrix`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [6, 14, 16, 18, 20]
+        node: [12, 14, 16, 18, 20]
     name: Test with Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,14 +2,28 @@ name: CI
 on: push
 jobs:
   test:
-    name: Test and check formatting
     runs-on: ubuntu-latest
-    container: node:14
+    strategy:
+      matrix:
+        node: [6, 14, 16, 18, 20]
+    name: Test with Node ${{ matrix.node }}
     steps:
-    - uses: actions/checkout@master
-    - name: Install dependencies
-      run: npm ci
-    - name: Run the tests
-      run: npm test
-    - name: Check code formatting
-      run: npm run prettier
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm ci
+      - run: npm test
+
+  format:
+    runs-on: ubuntu-latest
+    name: Check Formatting
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run prettier

--- a/lib/rules/sort-destructure-keys.js
+++ b/lib/rules/sort-destructure-keys.js
@@ -87,7 +87,6 @@ function isReferencedByOtherProperties(scope, objectPatternNode, id) {
 
 /**
  * Returns whether or not a node is safe to be sorted.
- * @param {import('estree').ObjectPattern['properties'][number]} node
  */
 function shouldCheck(scope, objectPatternNode, node) {
   if (node.type !== "Property") {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prettier": "^2.0.1"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": "> 12"
   },
   "license": "ISC",
   "files": [


### PR DESCRIPTION
Use the standard `actions/setup-node` and also test with different node versions so that we don't break `engines` compatibility. 