### PR TITLE
Update getScope call for ESLint 9 compatibility

### DIFF
--- a/lib/rules/sort-destructure-keys.js
+++ b/lib/rules/sort-destructure-keys.js
@@ -210,13 +210,16 @@ module.exports = {
   },
 
   create(context) {
+    const { sourceCode } = context;
     const options = context.options[0] || {};
     const { caseSensitive = true } = options;
     const sorter = createSorter(caseSensitive);
 
     return {
       ObjectPattern(objectPatternNode) {
-        const scope = context.getScope();
+        const scope = sourceCode.getScope
+          ? sourceCode.getScope(objectPatternNode)
+          : context.getScope();
 
         /*
          * If the node is more complex than just basic destructuring

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,15 +14,15 @@
       "devDependencies": {
         "@babel/core": "^7.15.8",
         "@babel/eslint-parser": "^7.15.8",
-        "eslint": "^8.1.0",
+        "eslint": "^8.37.0",
         "mocha": "^10.0.0",
         "prettier": "^2.0.1"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=12"
       },
       "peerDependencies": {
-        "eslint": "3 - 8"
+        "eslint": "3 - 9"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "format": "prettier --write \"{lib,tests}/**/*.js\""
   },
   "peerDependencies": {
-    "eslint": "3 - 8"
+    "eslint": "3 - 9"
   },
   "dependencies": {
     "natural-compare-lite": "^1.4.0"
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@babel/core": "^7.15.8",
     "@babel/eslint-parser": "^7.15.8",
-    "eslint": "^8.1.0",
+    "eslint": "^8.37.0",
     "mocha": "^10.0.0",
     "prettier": "^2.0.1"
   },


### PR DESCRIPTION
This adds compatibility with ESLint 9.

> `context.getScope()` is deprecated and has been removed in ESLint v9.0.0.

> We have introduced a new SourceCode#getScope(node) method that requires you to pass in the reference node. This method was added in ESLint v8.37.0 so it has already been in place for the last six months. For best compatibility, you can check for the presence of this new method to determine which one to use:

```js
module.exports = {
    create(context) {

        const { sourceCode } = context;

        return {
            Program(node) {
                const scope = sourceCode.getScope
                    ? sourceCode.getScope(node)
                    : context.getScope();

                // do something with scope
            }
        }
    }
};
```

See: https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#context.getscope()