### PR TITLE
Update runtime versions on `package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "prettier": "^3.8.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       },
       "peerDependencies": {
         "eslint": "5 - 10"

--- a/package.json
+++ b/package.json
@@ -27,8 +27,20 @@
     "eslint": "^9.39.2",
     "prettier": "^3.8.1"
   },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "onFail": "ignore",
+      "version": ">=11.6.2"
+    },
+    "runtime": {
+      "name": "node",
+      "onFail": "ignore",
+      "version": ">=20"
+    }
+  },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "license": "ISC",
   "files": [


### PR DESCRIPTION
## Description

- Set `engines.node` to `>=20` to match the change on PR #324. It was left as `>=18` while its commit https://github.com/mthadley/eslint-plugin-sort-destructure-keys/commit/3759058d17abb829484871171363c6eed6aebb5a raised the minimum version to 20.  
- Add missing change on `package-lock.json`.
- Add `devEngines` specifying `runtime` and `packageManager`.

  > Specifies requirements for development environment components such as operating systems, runtimes, or package managers. Used to ensure consistent development environments across the team.

  `onFail` was set to `ignore` to avoid breaking development environments that may not meet the specified versions. This allows for flexibility while still providing guidance on the recommended versions for development.

  See https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines